### PR TITLE
add LastServerDispatchSecondsAgo to heartbeats and use that to detect offline clients

### DIFF
--- a/ThwargLauncher/ThwargFilter/Heartbeat.cs
+++ b/ThwargLauncher/ThwargFilter/Heartbeat.cs
@@ -181,6 +181,7 @@ namespace ThwargFilter
             {
                 _status.TeamList = _cmdParser.GetTeamList();
                 _status.IsOnline = IsOnline();
+                _status.LastServerDispatchSecondsAgo = (int)(DateTime.UtcNow - FilterCore.GetLastServerDispatchUtc()).TotalSeconds;
                 LaunchControl.RecordHeartbeatStatus(_gameToLauncherFilepath, _status);
             }
             catch (Exception exc)

--- a/ThwargLauncher/ThwargFilter/HeartbeatGameStatus.cs
+++ b/ThwargLauncher/ThwargFilter/HeartbeatGameStatus.cs
@@ -17,5 +17,6 @@ namespace ThwargFilter
         public string ThwargFilterVersion;
         public string ThwargFilterFilePath;
         public bool IsOnline;
+        public int LastServerDispatchSecondsAgo;
     }
 }

--- a/ThwargLauncher/ThwargFilter/LaunchControl.cs
+++ b/ThwargLauncher/ThwargFilter/LaunchControl.cs
@@ -194,6 +194,7 @@ namespace ThwargFilter
                 stream.WriteLine("ThwargFilterVersion:{0}", assembly.GetName().Version);
                 stream.WriteLine("ThwargFilterFilePath:{0}", assembly.Location);
                 stream.WriteLine("IsOnline:{0}", status.IsOnline);
+                stream.WriteLine("LastServerDispatchSecondsAgo:{0}", status.LastServerDispatchSecondsAgo);
                 var text = stream.ToString();
                 return text;
             }
@@ -239,6 +240,7 @@ namespace ThwargFilter
                 info.Status.ThwargFilterVersion = SettingHelpers.GetSingleStringValue(settings, "ThwargFilterVersion");
                 info.Status.ThwargFilterFilePath = SettingHelpers.GetSingleStringValue(settings, "ThwargFilterFilePath");
                 info.Status.IsOnline = SettingHelpers.GetSingleBoolValue(settings, "IsOnline", false);
+                info.Status.LastServerDispatchSecondsAgo = SettingHelpers.GetSingleIntValue(settings, "LastServerDispatchSecondsAgo");
 
                 info.IsValid = true;
             }

--- a/ThwargLauncher/ThwargLauncher/GameManagement/GameMonitor.cs
+++ b/ThwargLauncher/ThwargLauncher/GameManagement/GameMonitor.cs
@@ -389,10 +389,10 @@ namespace ThwargLauncher
 
                 if (!response.Status.IsOnline)
                 {
-                    int gameInteractionTimeoutSeconds = ConfigSettings.GetConfigInt("GameInteractionTimeoutSeconds", 120);
+                    int gameInteractionTimeoutSeconds = ConfigSettings.GetConfigInt("GameInteractionTimeoutSeconds", 60);
                     // ThwargFilter reports !IsOnline if server dispatch quits firing
                     // but that isn't reliable, as it doesn't fire when not logged in to a character
-                    if ((DateTime.UtcNow - _lastOnlineTimeUtc).TotalSeconds > gameInteractionTimeoutSeconds)
+                    if (response.Status.LastServerDispatchSecondsAgo > gameInteractionTimeoutSeconds)
                     {
                         status = ServerAccountStatusEnum.None;
                         Logger.WriteInfo("Killing offline/character screen game");

--- a/ThwargLauncher/ThwargLauncher/GameManagement/GameMonitor.cs
+++ b/ThwargLauncher/ThwargLauncher/GameManagement/GameMonitor.cs
@@ -389,7 +389,7 @@ namespace ThwargLauncher
 
                 if (!response.Status.IsOnline)
                 {
-                    int gameInteractionTimeoutSeconds = ConfigSettings.GetConfigInt("GameInteractionTimeoutSeconds", 60);
+                    int gameInteractionTimeoutSeconds = ConfigSettings.GetConfigInt("GameInteractionTimeoutSeconds", 120);
                     // ThwargFilter reports !IsOnline if server dispatch quits firing
                     // but that isn't reliable, as it doesn't fire when not logged in to a character
                     if (response.Status.LastServerDispatchSecondsAgo > gameInteractionTimeoutSeconds)


### PR DESCRIPTION
_lastOnlineTimeUtc was a member of the GameMonitor instance, so if any game session was online it would refresh this and not kill other disconnected clients.